### PR TITLE
Update h5_util.py

### DIFF
--- a/utils/h5_util.py
+++ b/utils/h5_util.py
@@ -23,7 +23,11 @@ def process_image(image, shape, resize_mode=Image.BILINEAR):
     img = Image.open(image)
     img = img.resize(shape, resize_mode)
     img.load()
-    return np.asarray(img, dtype="float32")
+    img = np.asarray(img, dtype="float32")
+    if len(img.shape) < 3:
+        return img.T
+    else:
+        return np.transpose(img, (1,0,2))
 
 
 def build_h5_dataset(data_dir, list_path, out_dir, shape, name, norm=False):


### PR DESCRIPTION
columns and rows are switched by the image to numpy conversion. I had some errors. Since Tensorflow reads data NHWC: if the hf5 file should be kept in the NHWC format. instead of my changes the tuple should be flipped in the hf5 datset creation. if the tuple should be read as (height, width) it has to be flipped in the resize operation...