### PR TITLE
keep NHWC format in file

### DIFF
--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -54,7 +54,12 @@ class H5DataLoader(object):
             self.gen_indexes()
             return self.next_batch(batch_size)
         cur_indexes.sort()
-        return self.images[cur_indexes], self.labels[cur_indexes]
+        
+        if len(cur_indexes) :
+            return self.images[cur_indexes], self.names[cur_indexes]
+        else:
+            self.cur_index = 0
+            return  np.empty(0),  np.empty(0)
 
 
 class H53DDataLoader(object):

--- a/utils/h5_util.py
+++ b/utils/h5_util.py
@@ -23,19 +23,15 @@ def process_image(image, shape, resize_mode=Image.BILINEAR):
     img = Image.open(image)
     img = img.resize(shape, resize_mode)
     img.load()
-    img = np.asarray(img, dtype="float32")
-    if len(img.shape) < 3:
-        return img.T
-    else:
-        return np.transpose(img, (1,0,2))
+    return np.asarray(img, dtype="float32")
 
 
 def build_h5_dataset(data_dir, list_path, out_dir, shape, name, norm=False):
     images = read_images(list_path)
     images_size = len(images)
     dataset = h5py.File(out_dir+name+'.h5', 'w')
-    dataset.create_dataset('X', (images_size, *shape, 3), dtype='f')
-    dataset.create_dataset('Y', (images_size, *shape), dtype='f')
+    dataset.create_dataset('X', (images_size, shape[1], shape[0], 3), dtype='f')
+    dataset.create_dataset('Y', (images_size, shape[1], shape[0]), dtype='f')
     pbar = ProgressBar()
     for index, (image, label) in pbar(enumerate(images)):
         image = process_image(data_dir+image, shape)


### PR DESCRIPTION
The model reads the h5 file this way. As mentioned in my last pull request #42 ^^  Since the model reads the h5 file in NHWC as tensorflow does, the wh-tuple should be inverted for the h5dataset creation. Now it works as expected, erasing my previous fix for non-squared pictures.